### PR TITLE
Update converge.yml

### DIFF
--- a/converge.yml
+++ b/converge.yml
@@ -12,7 +12,7 @@
       ansible.builtin.command: >
         ansible-playbook -c local -v -b {{ remote_plugin.arguments }} --extra-vars='{{ remote_plugin.parameters }}' /rsc/plugins/{{ item.name}}/{{ item.path }}
       register: ansible_on_workspace
-      changed_when: "'changed=0' not in ansible_on_workspace.stdout_lines[-1]"
+      changed_when: "ansible_on_workspace.stdout_lines is not defined or 'changed=0' not in ansible_on_workspace.stdout_lines[-1]"
       vars:
         remote_plugin:
           script_type: Ansible PlayBook


### PR DESCRIPTION
Workaround absence of stdout_lines in case of module failures.

In case a module failure occurs on the workspace, the result object does not contain a `stdout_lines` attribute. This was causing confusing messages in the log. It is better to just assume `changed=true` when a failure occurs.