### PR TITLE
Add molecule CI workflow file

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -1,0 +1,46 @@
+---
+name: Molecule Run
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  molecule:
+   runs-on: ubuntu-latest
+    env:
+      DOCKER_USER: ${{ github.actor }}
+      DOCKER_PW: ${{ secrets.GITHUB_TOKEN }}
+      DOCKER_REGISTRY: ghcr.io
+      ANSIBLE_FORCE_COLOR: '1'
+      ANSIBLE_STDOUT_CALLBACK: yaml
+      MOLECULE_CONFIG: molecule.yml
+      REQUIREMENTS_FILE: requirements.txt
+      CRUN_VER: 1.11.2
+    steps:
+      - name: Workaround crun issue on ubuntu # https://github.com/UtrechtUniversity/SRC-catalog-items/issues/3
+        run: |
+          mkdir -p "${HOME}/.local/bin"
+          curl -L "https://github.com/containers/crun/releases/download/${CRUN_VER}/crun-${CRUN_VER}-linux-amd64" -o "${HOME}/.local/bin/crun"
+          chmod +x "${HOME}/.local/bin/crun"
+          crun --version
+          mkdir -p "${HOME}/.config/containers"
+          cat << EOF > "${HOME}/.config/containers/containers.conf"
+          [engine.runtimes]
+          crun = [
+            "${HOME}/.local/bin/crun",
+            "/usr/bin/crun"
+          ]
+          EOF
+      - name: Checkout
+        uses: actions/checkout@v4
+      - run: git clone https://github.com/UtrechtUniversity/SRC-molecule-test.git molecule
+      - run: pip install -r ${{ env.REQUIREMENTS_FILE }}
+      - run: ansible-galaxy install -r requirements.yml
+      - name: Molecule tests
+        run: |
+          molecule -vv test
+


### PR DESCRIPTION
Adds a simple molecule run to CI that tests the molecule configuration in this repository with a test component (https://github.com/UtrechtUniversity/SRC-molecule-test) .