### PR TITLE
Update converge.yml

### DIFF
--- a/_run_component.yml
+++ b/_run_component.yml
@@ -1,0 +1,25 @@
+---
+- name: "Set python version for component {{ item.name }}"
+  ansible.builtin.set_fact:
+    python_version: "{{ item.python_version | default('3.10') }}"
+
+- name: "Set remote ansible version for component {{ item.name }}"
+  ansible.builtin.set_fact:
+    remote_ansible_version: "{{ item.remote_ansible_version | default('9.1.0') }}"
+
+- name: Setup ansible
+  ansible.builtin.include_tasks: _setup_ansible.yml
+
+- name: Test the component by executing it using ansible on the workspace
+  ansible.builtin.command: >
+    {{ venv_location }}/bin/ansible-playbook -c local -v -b {{ remote_plugin.arguments }}
+    --extra-vars='ansible_python_interpreter={{ python_location }}'
+    --extra-vars='{{ remote_plugin.parameters }}'
+    /rsc/plugins/{{ item.name }}/{{ item.path }}
+  register: ansible_on_workspace
+  changed_when: "ansible_on_workspace.stdout_lines is not defined or 'changed=0' not in ansible_on_workspace.stdout_lines[-1]"
+  vars:
+    remote_plugin:
+      script_type: Ansible PlayBook
+      arguments: -i 127.0.0.1, --skip-tags {{ ansible_skip_tags | join(',') }}
+      parameters: "{{ item.parameters | default({}) | to_json }}"

--- a/_setup_ansible.yml
+++ b/_setup_ansible.yml
@@ -1,0 +1,41 @@
+---
+- name: Install Python and Ansible for Ubuntu
+  when: ansible_distribution == 'Ubuntu'
+  block:
+
+    - name: Set deadsnakes key download location
+      ansible.builtin.set_fact:
+        key_location: /usr/share/keyrings/deadsnakes.asc
+
+    - name: Download deadsnakes key
+      ansible.builtin.get_url:
+        url: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776
+        dest: "{{ key_location }}"
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: Add deadsnakes repo
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by={{ key_location }}] https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu {{ ansible_distribution_release }} main"
+        state: present
+        filename: deadsnakes
+
+    - name: Install python
+      ansible.builtin.apt:
+        pkg:
+          - "python{{ python_version }}"
+          - "python{{ python_version }}-venv"
+        state: present
+
+    - name: Set venv location
+      ansible.builtin.set_fact:
+        venv_location: "/root/ansible_env{{ python_version }}"
+
+    - name: Install ansible
+      pip:
+        name: "ansible=={{ remote_ansible_version }}"
+        virtualenv: "{{ venv_location }}"
+        virtualenv_command: "python{{ python_version }} -m venv"
+
+    - name: Set python location
+      ansible.builtin.set_fact:
+        python_location: "{{ venv_location }}/bin/python3"

--- a/converge.yml
+++ b/converge.yml
@@ -1,21 +1,13 @@
 ---
 - name: Converge
   hosts: all
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Debug -- list all components to be executed
       ansible.builtin.debug:
         msg: "{{ item.name }}"
       with_items: "{{ lookup('env', 'components') }}"
 
-    - name: Test the component by executing it using ansible on the workspace
-      ansible.builtin.command: >
-        ansible-playbook -c local -v -b {{ remote_plugin.arguments }} --extra-vars='{{ remote_plugin.parameters }}' /rsc/plugins/{{ item.name}}/{{ item.path }}
-      register: ansible_on_workspace
-      changed_when: "ansible_on_workspace.stdout_lines is not defined or 'changed=0' not in ansible_on_workspace.stdout_lines[-1]"
-      vars:
-        remote_plugin:
-          script_type: Ansible PlayBook
-          arguments: -i 127.0.0.1, --skip-tags {{ ansible_skip_tags | join(',') }}
-          parameters: "{{ item.parameters | default({}) | to_json }}"
+    - name: Run component
+      ansible.builtin.include_tasks: _run_component.yml
       with_items: "{{ lookup('env', 'components') }}"

--- a/prepare.yml
+++ b/prepare.yml
@@ -25,12 +25,12 @@
         ssh_connection_multiplexing: true
       with_items: "{{ lookup('env', 'components') }}"
 
-    # Apt cache is normally updated at deploy time by the SRC-OS component.
-    # Make sure it is fresh so our tests use recent apt repo information.
-    - name: Update apt cache
+    - name: Install dependencies
       ansible.builtin.apt:
+        pkg:
+          - dirmngr
         update_cache: true
-      when: ansible_os_family == 'Debian'
+      when: ansible_pkg_mgr == 'apt'
 
     - name: Set extra_preparations var
       ansible.builtin.set_fact:


### PR DESCRIPTION
Explicitly specify python interpreter location.

SURF is working on a change that would use a separate venv for the Ansible python interpreter. This PR anticipates this change.