### PR TITLE
Refactor converge.yml and prepare.yml for simplicity

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -8,10 +8,27 @@ on:
   
 jobs:
   build:
+    name: Ansible Lint # Naming the build is important to use it as a status check
     runs-on: ubuntu-latest
-    name: Ansible Lint
+    env:
+      VIRTUAL_ENV: ${{ github.workspace }}/.venv
     steps:
-      # Important: This sets up your GITHUB_WORKSPACE environment variable
+      - name: Set Up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Set up UV and caching
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+
       - uses: actions/checkout@v7
-      - name: Run ansible-lint
-        uses: ansible/ansible-lint@v26.6.0
+      - name: Install Dependencies
+        run: |
+          uv venv $VIRTUAL_ENV
+          uv pip install ansible-lint
+
+      - name: Run Ansible Lint
+        run: |
+          uv run ansible-lint .

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ That's it for setup! You're now ready to start [adding your own scenarios](#addi
 
 Molecule runs tests for each *scenario* defined under the `molecule` directory. You can think of each scenario as a self-contained test suite. A scenario is just a subdirectory of the `molecule` directory that contains a number of configuration files and playbooks. For our purposes, these are minimally:
 
-* `molecule.yml` - sets general configuration variables for the test suite (e.g. what platform to run on). Overrides the defaults in `molecule/ext/molecule-src/molecule.yml`.
+* `molecule.yml` - sets general configuration variables for the test suite (e.g. what images to run the tests on). Overrides the defaults in `molecule/ext/molecule-src/molecule.yml`.
 * `prepare.yml`  - a playbook used to make preparations on the container before running the Ansible code that we want to test on it.
 * `converge.yml` - a playbook that specifies how to deploy the Ansible role or playbook that we want to test on the container.
 * `verify.yml`   - a playbook that contains additional test assertions after the `converge` step is run.
@@ -73,27 +73,23 @@ We want this procedure because that is [how components are actually deployed ont
 
 To help us achieve this, the `default` scenario contains a `prepare.yml` that takes care of 1., and a `converge.yml` that takes care of 2. Each individual scenario will automatically use these default playbooks, as long as `molecule` is run with the ` -c molecule/default/molecule.yml`.
 
+Information about the component that should be executed for each scenario is defined by a `.env.yml` file inside the scenario. See [here](#adding-scenarios).
+
 ### Adding scenarios
 
 To create a Molecule scenario to test, just create a subdirectory of the `molecule` directory, e.g.:
 
 `mkdir molecule/my-component`
 
-Now add a `molecule.yml` file to the `my-component` subdirectory, with contents like the following:
+Now add a `.env.yml` file to the `my-component` subdirectory, with contents like the following:
 
 ```yaml
-provisioner:
-  name: ansible
-  env:
-    components:
-      - name: my-component
-        path: my-component.yaml
-        parameters: # Define all parameters needed by the component here
-          my_component_param1: 'Foo'
-      - name: my-git-component # You can also provide components that should be cloned onto the workspace using git
-        git: https://github.com/foo/bar.git
-        version: my_branch
-        path: playbook.ymk
+---
+components:
+  - path: my-component.yaml
+    # dir: /path/to/directory # this is not necessary -- the default is to use the directory defined by the PLAYBOOK_DIR env variable, set in molecule.yml
+    parameters: # Define all parameters needed by the component here
+      my_component_param1: 'Foo'
 ```
 
 The above config file does not provide a `platforms` key, so tests for this scenario will use the default platforms (containers) specified in `molecule/ext/molecule-src/molecule.yml` (Ubuntu Focal and Ubuntu Jammy). You can override this by adding your own platform definition, e.g.:
@@ -118,7 +114,7 @@ The molecule tests can use either Docker or Podman (default). You can override t
 
 ### Adding additional preparation tasks
 
-Sometimes it may be helpful to perform certain tasks before the `converge` step. The default `prepare.yml` playbook will check if the user has set the `extra_prepare_tasks` key in the scenario's `molecule.yml` `env` section. Set this key to a relative path to a playbook (relative to the location of the default molecule configuration), and the tasks in that playbook will be executed at the end of the `prepare` step.
+Sometimes it may be helpful to perform certain tasks before the `converge` step. The default `prepare.yml` playbook will check if the user has defined a `prepare.yml` inside the scenario, and that playbook will be executed at the end of the `prepare` step.
 
 ### Adding additional assertions
 

--- a/_empty.yml
+++ b/_empty.yml
@@ -1,0 +1,8 @@
+---
+- name: Skip extra preparations
+  hosts: all
+  gather_facts: false
+  tasks: []
+  # see prepare.yml
+  # this is a workaround for the fact that import_playbook can't take a variable set at runtime as argument.
+  # this file provides a fallback in case no additional prepare.yml was found in the scenario directory.

--- a/_run_component.yml
+++ b/_run_component.yml
@@ -4,12 +4,12 @@
   block:
     - name: Check for plugin requirements file
       stat:
-        path: /rsc/plugins/{{ remote_plugin.script_folder }}/requirements.yml
+        path: "{{ remote_plugin.script_folder }}/requirements.yml"
       register: register_requirements_1
 
     - name: Check for plugin requirements file 2
       stat:
-        path: /rsc/plugins/{{ remote_plugin.script_folder }}/{{ remote_plugin.path | dirname }}/requirements.yml
+        path: "{{ remote_plugin.script_folder }}/{{ remote_plugin.path | dirname }}/requirements.yml"
       register: register_requirements_2
 
     - name: Set path to file 1 if it exists
@@ -25,29 +25,27 @@
     - name: Install role dependencies for Ansible plugin
       when: requirements_path is defined
       command: |
-        uv run ansible-galaxy role install -r {{ requirements_path }} -p /rsc/plugins/{{ remote_plugin.script_folder | basename }}
+        uv run ansible-galaxy role install -r {{ requirements_path }} -p {{ remote_plugin.script_folder }}
       args:
-        chdir: /rsc/plugins/{{ remote_plugin.script_folder | basename }}
-        executable: /bin/bash
+        chdir: "{{ remote_plugin.script_folder }}"
       environment:
         VIRTUAL_ENV: "{{ lookup('env', 'WORKSPACE_ANSIBLE_VENV') | default('/etc/src/venv/ansible_env', true) }}"
-        ANSIBLE_COLLECTIONS_PATH: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}:/rsc/plugins/{{ remote_plugin.script_folder | basename }}"
+        ANSIBLE_COLLECTIONS_PATHS: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATHS') }}:{{ remote_plugin.script_folder }}"
 
     - name: Install collection dependencies for Ansible plugin
       when: requirements_path is defined
       command: |
-        uv run ansible-galaxy collection install -r {{ requirements_path }} -p /rsc/plugins/{{ remote_plugin.script_folder | basename }}/collections
+        uv run ansible-galaxy collection install -r {{ requirements_path }} -p {{ remote_plugin.script_folder }}/collections
       args:
-        chdir: /rsc/plugins/{{ remote_plugin.script_folder | basename }}
-        executable: /bin/bash
+        chdir: "{{ remote_plugin.script_folder }}"
       environment:
         VIRTUAL_ENV: "{{ lookup('env', 'WORKSPACE_ANSIBLE_VENV') | default('/etc/src/venv/ansible_env', true) }}"
-        ANSIBLE_COLLECTIONS_PATH: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}:/rsc/plugins/{{ remote_plugin.script_folder | basename }}"
+        ANSIBLE_COLLECTIONS_PATHS: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATHS') }}:{{ remote_plugin.script_folder }}"
 
 - name: Test the component by executing it using ansible on the workspace
   ansible.builtin.command: >
-    uv run ansible-playbook -c local -v -b {{ remote_plugin.arguments }} -e='{{ remote_plugin.parameters }}' /rsc/plugins/{{ remote_plugin.script_folder
-    }}/{{remote_plugin.path }}
+    uv run ansible-playbook
+    -c local -v -b {{ remote_plugin.arguments }} -e='{{ remote_plugin.parameters }}' {{ remote_plugin.script_folder }}/{{ remote_plugin.path }}
   register: ansible_on_workspace
   changed_when: >
     ansible_on_workspace.stdout_lines is not defined or
@@ -55,4 +53,4 @@
     ansible_on_workspace.stdout_lines[ lookup('ansible.utils.index_of', ansible_on_workspace.stdout_lines, 'regex', '\s*PLAY RECAP\s*', wantlist=True)[0]+1 ]
   environment:
     VIRTUAL_ENV: "{{ lookup('env', 'WORKSPACE_ANSIBLE_VENV') | default('/etc/src/venv/ansible_env', true) }}"
-    ANSIBLE_COLLECTIONS_PATH: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}:/rsc/plugins/{{ remote_plugin.script_folder | basename }}"
+    ANSIBLE_COLLECTIONS_PATHS: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATHS') }}:{{ remote_plugin.script_folder | basename }}"

--- a/converge.yml
+++ b/converge.yml
@@ -2,12 +2,13 @@
 - name: Converge
   hosts: all
   gather_facts: false
+  vars:
+    target_dir: "/rsc/plugins/{{ item.path | basename | splitext | first }}/"
+  vars_files:
+    - "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/.env.yml" # should set 'components'
   tasks:
-    - name: Debug -- list all components to be executed
-      ansible.builtin.debug:
-        msg: "{{ item.name }}"
-      with_items: "{{ lookup('env', 'components') | from_yaml }}"
-
+    # here we mimick the SRC-External plugin: https://gitlab.com/rsc-surf-nl/plugins/plugin-external-plugin
+    # in the future, we might use the actual SRC-External plugin for testing
     - name: Run components
       ansible.builtin.include_tasks: _run_component.yml
       vars:
@@ -15,6 +16,6 @@
           script_type: Ansible PlayBook
           arguments: -i 127.0.0.1, --skip-tags {{ ansible_skip_tags | join(',') }}
           parameters: "{{ item.parameters | default({}) | to_json }}"
-          script_folder: "{{ item.name }}"
+          script_folder: "{{ target_dir }}"
           path: "{{ item.path }}"
-      with_items: "{{ lookup('env', 'components') | from_yaml }}"
+      with_items: "{{ components }}"

--- a/prepare.yml
+++ b/prepare.yml
@@ -2,28 +2,28 @@
 - name: Prepare
   hosts: all
   gather_facts: true
+  vars:
+    target_dir: "/rsc/plugins/{{ item.path | basename | splitext | first }}/"
+    src_dir: "{{ item.dir | default(lookup('env', 'PLAYBOOK_DIR')) }}/"
+  vars_files:
+    - "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/.env.yml" # should set 'components'
   tasks:
-    - name: Clone git component
-      when: item.git is defined
-      ansible.builtin.git:
-        repo: "{{ item.git }}"
-        dest: /rsc/plugins/{{ item.name }}/
-        version: "{{ item.version | default(omit) }}"
-      with_items: "{{ lookup('env', 'components') }}"
-      tags: skip_ansible_lint # linter complains about idempotence of git module
+    - name: Debug -- list all components to be executed
+      ansible.builtin.debug:
+        msg: "Playbook: {{ item.path }} in {{ src_dir }} will be copied to {{ target_dir }}."
+      with_items: "{{ components }}"
 
-    - name: Copy local component
-      when: item.git is not defined
+    - name: Copy local component dir
       ansible.posix.synchronize:
-        src: "{{ item.dir | default(lookup('env', 'PLAYBOOK_DIR')) }}/"
-        dest: /rsc/plugins/{{ item.name }}/
+        src: "{{ src_dir }}"
+        dest: "{{ target_dir }}"
         archive: false
         links: true
         recursive: true
         rsync_opts:
           - --exclude=".*"
         ssh_connection_multiplexing: true
-      with_items: "{{ lookup('env', 'components') | from_yaml }}"
+      with_items: "{{ components }}"
 
     # Apt cache is normally updated at deploy time by the SRC-OS component.
     # Make sure it is fresh so our tests use recent apt repo information.
@@ -32,10 +32,8 @@
         update_cache: true
       when: ansible_os_family == 'Debian'
 
-    - name: Set extra_preparations var
-      ansible.builtin.set_fact:
-        extra_preparations: "{{ lookup('env', 'extra_prepare_tasks' | default(omit)) }}"
-
-    - name: Execute optional extra preparations
-      ansible.builtin.include_tasks: "{{ extra_preparations }}"
-      when: extra_preparations != ""
+- name: Execute optional extra preparations
+  # check if a prepare.yml exists in the scenario's directory, and if so, run it.
+  # if not, run the dummy _empty.yml playbook instead.
+  # this is a workaround for the fact that import_playbook can't take a variable set at runtime as argument.
+  ansible.builtin.import_playbook: "{{ query('fileglob', lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') ~ '/prepare.yml') | length | ternary(lookup('env','MOLECULE_SCENARIO_DIRECTORY') ~ '/prepare.yml', '_empty.yml') }}" # noqa yaml[line-length]


### PR DESCRIPTION
1. Execute $MOLECULE_SCENARIO_DIR/prepare.yml if it exists, obviating the need to define an extra_preparations key in molecule.yml
2. From now on scenarios need to contain a .env.yml file to define components that will be executed. This obviates the need to override the provisioner key in a scenario's molecule.yml